### PR TITLE
Update README to flag extension still works.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,8 @@
 ckanext-adfs
 ------------
 
+As of 2018-05-10 this extension works with CKAN 2.7.3 and has it's tests passing however, YMMV.
+
 A CKAN extension for validating users against Microsoft's Active Directory
 Federated Services (ADFS) Single Sign On (SSO) API.
 


### PR DESCRIPTION
Although inactive, this plugin still works and has it's tests passing.
I thought this would be a beneficial comment to add for future developers
looking for a similar solution.